### PR TITLE
Si non admin et aucune session, on redirige vers la page d'accueil projet à l'authentification

### DIFF
--- a/src/Controller/GramcSessionController.php
+++ b/src/Controller/GramcSessionController.php
@@ -230,7 +230,10 @@ class GramcSessionController extends AbstractController
         // Lors de l'installation, aucune session n'existe: redirection
         // vers l'écran de création de session, le seul qui fonctionne !
         if ($session == null) {
-            return $this->redirectToRoute('gerer_sessions');
+            if ($this->ac->isGranted('ROLE_ADMIN')) {
+                return $this->redirectToRoute('gerer_sessions');
+            }
+            return $this->redirectToRoute('projet_accueil');
         }
 
         // Si true, cet utilisateur n'est ni expert ni admin ni président !


### PR DESCRIPTION
Lors de l'authentification avec un compte non admin, si aucune session n'existe, l'utilisateur est redirigé vers la page d'accueil approprié